### PR TITLE
Remove expense and time approval fields from workspace update

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1032,8 +1032,6 @@ workspaces:
     - posts_require_privacy_decision
     - stories_are_fixed_fee_by_default
     - currency
-    - require_expense_approvals
-    - require_time_approvals
 
 workspace_invoice_preferences:
   attributes:


### PR DESCRIPTION
These fields are not supported when updating workspaces.