### PR TITLE
Remove duplicate require statement

### DIFF
--- a/lib/mavenlink.rb
+++ b/lib/mavenlink.rb
@@ -117,5 +117,4 @@ require 'mavenlink/workspace_invoice_preference'
 require 'mavenlink/workspace_group'
 require 'mavenlink/workweek'
 require 'mavenlink/workweek_membership'
-require 'mavenlink/external_reference'
 require 'mavenlink/railtie' if defined?(Rails)


### PR DESCRIPTION
This removes the duplicate require for `external_reference`

As a note, there are 131 failing specs on master and they appear to have been there for awhile now. My assumption is that it's either due to local setup or missing env file because on CI, the specs are green: https://circleci.com/gh/mavenlink/mavenlink_gem/77