### PR TITLE
Add attributes 'access_level' to workspaces

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1097,6 +1097,7 @@ workspaces:
     - require_expense_approvals
     - require_time_approvals
     - percentage_complete
+    - access_level
   create_attributes:
     - title
     - creator_role


### PR DESCRIPTION
The field `access_level` was missing from the workspace attributes.