### PR TITLE
Include status when returning response from requests to mavenlink

### DIFF
--- a/lib/mavenlink/client.rb
+++ b/lib/mavenlink/client.rb
@@ -40,7 +40,8 @@ module Mavenlink
     # @param [Hash] arguments
     def get(path, arguments = {})
       Mavenlink.logger.note "Started GET /#{path} with #{arguments.inspect}"
-      parse_request(connection.get(path, arguments).body)
+      response = connection.get(path, arguments)
+      parse_request(response.body, response.status)
     end
 
     # Performs custom POST request
@@ -48,7 +49,8 @@ module Mavenlink
     # @param [Hash] arguments
     def post(path, arguments = {})
       Mavenlink.logger.note "Started POST /#{path} with #{arguments.inspect}"
-      parse_request(connection.post(path, arguments).body)
+      response = connection.post(path, arguments)
+      parse_request(response.body, response.status)
     end
 
     # Performs custom PUT request
@@ -56,7 +58,8 @@ module Mavenlink
     # @param [Hash] arguments
     def put(path, arguments = {})
       Mavenlink.logger.note "Started PUT /#{path} with #{arguments.inspect}"
-      parse_request(connection.put(path, arguments).body)
+      response = connection.put(path, arguments)
+      parse_request(response.body, response.status)
     end
 
     # Performs custom PUT request
@@ -64,7 +67,8 @@ module Mavenlink
     # @param [Hash] arguments
     def delete(path, arguments = {})
       Mavenlink.logger.note "Started DELETE /#{path} with #{arguments.inspect}"
-      parse_request(connection.delete(path, arguments).body)
+      response = connection.delete(path, arguments)
+      parse_request(response.body, response.status)
     end
 
     private
@@ -87,16 +91,16 @@ module Mavenlink
       }.freeze
     end
 
-    def parse_request(response)
-      if response.present?
-        parsed_response = JSON.parse(response)
+    def parse_request(body, status)
+      if body.present?
+        parsed_response = JSON.parse(body).merge("status" => status)
       else
         return
       end
 
       parsed_response.tap do
         Mavenlink.logger.whisper 'Received response:'
-        Mavenlink.logger.inspection response
+        Mavenlink.logger.inspection body
 
         case parsed_response
         when Array

--- a/spec/lib/mavenlink/client_spec.rb
+++ b/spec/lib/mavenlink/client_spec.rb
@@ -147,22 +147,35 @@ describe Mavenlink::Client, stub_requests: true do
     let(:post_path)   { '/post_something' }
     let(:put_path)    { '/put_something' }
     let(:delete_path) { '/delete_something' }
+    let(:failing_get_path) { '/fail_to_get_something' }
 
-    let(:get_response)    { {'get'    => true} }
-    let(:post_response)   { {'post'   => true} }
-    let(:put_response)    { {'put'    => true} }
-    let(:delete_response) { {'delete' => true} }
+    let(:get_body)    { {'get'    => true} }
+    let(:post_body)   { {'post'   => true} }
+    let(:put_body)    { {'put'    => true} }
+    let(:delete_body) { {'delete' => true} }
+    let(:failing_get_body) { {'get' => "errors"} }
+
+    let(:get_response)    { get_body.merge({'status' => 200}) }
+    let(:post_response)   { post_body.merge({'status' => 200}) }
+    let(:put_response)    { put_body.merge({'status' => 200}) }
+    let(:delete_response) { delete_body.merge({'status' => 200}) }
+    let(:failing_get_response) { failing_get_body.merge({'status' => 403}) }
 
     before do
-      stub_request :get,    get_path,    get_response
-      stub_request :post,   post_path,   post_response
-      stub_request :put,    put_path,    put_response
-      stub_request :delete, delete_path, delete_response
+      stub_request :get,    get_path,    get_body
+      stub_request :post,   post_path,   post_body
+      stub_request :put,    put_path,    put_body
+      stub_request :delete, delete_path, delete_body
+      stub_request :get,    failing_get_path, failing_get_body, 403
     end
 
     describe '#get' do
       specify do
         expect(subject.get(get_path)).to eq(get_response)
+      end
+
+      specify do
+        expect(subject.get(failing_get_path)).to eq(failing_get_response)
       end
     end
 

--- a/spec/lib/mavenlink/request_spec.rb
+++ b/spec/lib/mavenlink/request_spec.rb
@@ -13,7 +13,8 @@ describe Mavenlink::Request, stub_requests: true do
       'workspaces' => {
         '7' => {'title' => 'My new project'},
         '9' => {'title' => 'My second project'},
-      }
+      },
+      'status' => 200,
     }
   }
 
@@ -22,8 +23,9 @@ describe Mavenlink::Request, stub_requests: true do
       'count' => 1,
       'results' => [{'key' => 'workspaces', 'id' => '7'}],
       'workspaces' => {
-        '7' => {'title' => 'My new project'}
-      }
+        '7' => {'title' => 'My new project'},
+      },
+      'status' => 200,
     }
   }
 
@@ -34,7 +36,8 @@ describe Mavenlink::Request, stub_requests: true do
       'workspaces' => {
         '7' => {'title' => 'My new project!'},
         '9' => {'title' => 'My second project!'},
-      }
+      },
+      'status' => 200,
     }
   }
 
@@ -44,7 +47,8 @@ describe Mavenlink::Request, stub_requests: true do
       'results' => [{'key' => 'workspaces', 'id' => '10'}],
       'workspaces' => {
         '10' => {'title' => 'My last project!'}
-      }
+      },
+      'status' => 200,
     }
   }
 
@@ -54,7 +58,14 @@ describe Mavenlink::Request, stub_requests: true do
       'results' => [{'key' => 'workspaces', 'id' => '11'}],
       'workspaces' => {
         '11' => {'title' => 'Not existed project'}
-      }
+      },
+      'status' => 200,
+    }
+  }
+
+  let(:delete_response) {
+    {
+      'status' => 204,
     }
   }
 
@@ -65,7 +76,7 @@ describe Mavenlink::Request, stub_requests: true do
     stub_request :get,    '/api/v1/workspaces?only=7', one_record_response
     stub_request :get,    '/api/v1/workspaces?only=8', { 'count' => 0, 'results' => [] }
     stub_request :put,    '/api/v1/workspaces/7',      one_record_response
-    stub_request :delete, '/api/v1/workspaces/7',      {}
+    stub_request :delete, '/api/v1/workspaces/7',      {}, 204
     stub_request :get,    '/api/v1/workspaces',        response
     stub_request :post,   '/api/v1/workspaces',        one_record_response
   end
@@ -271,7 +282,7 @@ describe Mavenlink::Request, stub_requests: true do
 
   describe '#delete' do
     specify do
-      expect(request.only(7).delete).to be_blank
+      expect(request.only(7).delete).to eq delete_response
     end
 
     context 'no id specified' do

--- a/spec/lib/mavenlink/story_allocation_day_spec.rb
+++ b/spec/lib/mavenlink/story_allocation_day_spec.rb
@@ -21,7 +21,14 @@ describe Mavenlink::StoryAllocationDay, stub_requests: true do
       'results' => [{'key' => 'story_allocation_days', 'id' => '7'}],
       'story_allocation_days' => {
         '7' => {'current' => true, 'id' => '7'}
-      }
+      },
+      'status' => 200,
+    }
+  }
+
+  let(:delete_response) {
+    {
+      'status' => 204,
     }
   }
 
@@ -29,7 +36,7 @@ describe Mavenlink::StoryAllocationDay, stub_requests: true do
     stub_request :get,    "/api/v1/story_allocation_days?only=7", response
     stub_request :get,    "/api/v1/story_allocation_days?only=8", {'count' => 0, 'results' => []}
     stub_request :post,   "/api/v1/story_allocation_days", response
-    stub_request :delete, "/api/v1/story_allocation_days/4", {}
+    stub_request :delete, "/api/v1/story_allocation_days/4", {}, 204
   end
 
   describe '#save' do
@@ -58,7 +65,7 @@ describe Mavenlink::StoryAllocationDay, stub_requests: true do
 
   describe '#destroy' do
     specify do
-      expect(described_class.new(id: '4').destroy).to be_blank
+      expect(described_class.new(id: '4').destroy).to eq(delete_response)
     end
   end
 end

--- a/spec/lib/mavenlink/story_spec.rb
+++ b/spec/lib/mavenlink/story_spec.rb
@@ -29,11 +29,17 @@ describe Mavenlink::Story, stub_requests: true do
     }
   }
 
+  let(:delete_response) {
+    {
+      'status' => 204
+    }
+  }
+
   before do
     stub_request :get,    "/api/v1/stories?only=7", response
     stub_request :get,    "/api/v1/stories?only=8", {'count' => 0, 'results' => []}
     stub_request :post,   "/api/v1/stories", response
-    stub_request :delete, "/api/v1/stories/4", {}
+    stub_request :delete, "/api/v1/stories/4", {}, 204
   end
 
   describe '#save' do
@@ -62,7 +68,7 @@ describe Mavenlink::Story, stub_requests: true do
 
   describe '#destroy' do
     specify do
-      expect(described_class.new(id: '4').destroy).to be_blank
+      expect(described_class.new(id: '4').destroy).to eq(delete_response)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,8 @@ shared_context 'stubbed requests', stub_requests: true do
     Mavenlink.adapter = [:test, stubbed_requests]
   end
 
-  def stub_request(request_type, path, response)
-    stubbed_requests.public_send(request_type, path) { [200, {}, response.to_json] }
+  def stub_request(request_type, path, response, status = 200)
+    stubbed_requests.public_send(request_type, path) { [status, {}, response.to_json] }
   end
 end
 


### PR DESCRIPTION
This proposed change would include the status in the response of any request from Mavenlink. The main purpose of this change is to [use the status code to determine the type of error on our integrations platform](https://github.com/mavenlink-solutions/konekti/pull/984).  

For most requests (GET, POST, PUT) we are just adding a status code to the hash that's returned from the gem. However, for DELETE, the response has historically been a blank hash. Adding in the status code would yield a hash with just a status code. Thus, if any users of the gem are checking for `response.blank?` on a delete request, we will be introducing a breaking change. 

We would appreciate comments as to whether this is an appropriate change to the gem. 

For the time being, we are able to look for specific error messages on the integrations platform, so this is a desired change but not required for us to properly handle the errors. We would prefer to use the error code so that we do not have to couple the integrations platform to the Mavenlink API around specific error messages. 
