### PR TITLE
Add missing custom field attributes

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -180,6 +180,7 @@ custom_fields:
     - read_access # the permission level required to read values for this custom field
     - created_at # the date the CF was created
     - updated_at # the date the CF was last updated
+    - values_count
   create_attributes:
     - name # (required) the given field name
     - value_type # (optional) the types the Custom Field Values use. The current types include: 'string', 'date', 'number', and 'currency'
@@ -187,10 +188,15 @@ custom_fields:
     - unique_constraint # (optional) a boolean constraint which forces the Custom Field Values' value to be unique across a subject_type. The default is false
     - choices # (optional) the choices a custom field may have and only valid for a 'single' and 'multi' type custom fields. eg. [{'label' => 'first choice'}, {'label' => 'another choice'}]
     - custom_field_set_id # (optional) the custom field set the custom field will belong to. If the custom_field_set_id is omitted this field will belong to a Workspace set named 'Default Project Set'. Note omitting the set id will restrict this field to only be applied to workspaces.
+    - write_access
+    - read_access
   update_attributes:
     - name # (required) the given field name
+    - value_type
     - default_text # (optional) the placeholder text
+    - unique_constraint
     - choices # choices may be updated through their CF's choices attribute. To change a choice's name, specify the id. To add new choices, do not specify and id. eg. [{'id' => '1', 'label' => 'new first choice name'}, {'label' => 'a brand new choice'}]. If a previous choice of the custom field is omitted, that choice will be soft deleted so that the values will not point to invalid choices.
+    - custom_field_set_id
     - write_access # (optional) the permission level required for a user to create, update, or delete a custom field value for an object.
     - read_access # (optional) the permission level required to read a custom field value for an object.
   associations:


### PR DESCRIPTION
This PR adds some missing fields to CustomField `attributes`, `create_attributes`, and `update_attributes`