### PR TITLE
Add `primary_maven_id` to workspaces specification

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1652,6 +1652,7 @@ workspaces:
     - status_key
     - workspace_group_ids
     - target_margin
+    - primary_maven_id
   create_attributes:
     - title
     - creator_role


### PR DESCRIPTION
This P.R. adds `primary_maven_id` to workspaces attributes.