### PR TITLE
Remove workspace `custom_field_values` association

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1665,9 +1665,6 @@ workspaces:
     financial_viewers:
       foreign_key: financial_viewer_ids
       collection: users
-    custom_field_values:
-      foreign_key: custom_field_value_ids
-      collection: custom_field_values
     possible_approvers:
       foreign_key: possible_approver_ids
       collection: users

--- a/spec/lib/mavenlink/workspace_spec.rb
+++ b/spec/lib/mavenlink/workspace_spec.rb
@@ -19,7 +19,6 @@ describe Mavenlink::Workspace, stub_requests: true do
     it { should respond_to :timesheet_submissions }
     it { should respond_to :workspace_groups }
     it { should respond_to :financial_viewers }
-    it { should respond_to :custom_field_values }
     it { should respond_to :possible_approvers }
     it { should respond_to :workspace_resources }
     it { should respond_to :workspace_resources_with_unnamed }


### PR DESCRIPTION
Adding this association breaks existing calls we have using `workspace.custom_field_values.each_page.entries.flatten`. I will come back and revisit updating this association and its existing uses, but in the meantime master should not have these breaking changes.