### PR TITLE
Make Timesheet Submission External Reference association plural

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1626,7 +1626,7 @@ timesheet_submissions:
         foreign_key: resolution_ids
         collection: resolutions
       external_references:
-        foreign_key: external_reference_id
+        foreign_key: external_reference_ids
         collection: external_references
 
 users:

--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1625,7 +1625,7 @@ timesheet_submissions:
       resolutions:
         foreign_key: resolution_ids
         collection: resolutions
-      external_reference:
+      external_references:
         foreign_key: external_reference_id
         collection: external_references
 

--- a/spec/lib/mavenlink/timesheet_submission_spec.rb
+++ b/spec/lib/mavenlink/timesheet_submission_spec.rb
@@ -8,7 +8,7 @@ describe Mavenlink::TimesheetSubmission, stub_requests: true do
     it { should respond_to :workspace }
     it { should respond_to :time_entries }
     it { should respond_to :resolutions }
-    it { should respond_to :external_reference }
+    it { should respond_to :external_references }
   end
 
   it 'should respond to expected attributes' do


### PR DESCRIPTION
The association is a has many relationship and should be plural.