### PR TITLE
Add `workspace_id` to Additional Items

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -43,6 +43,7 @@ additional_items:
     - amount_in_cents
     - taxable
     - currency
+    - workspace_id
 
 account_memberships:
   attributes:


### PR DESCRIPTION
Adding workspace_id to additional items after updating the Mavenlink API to include the attribute.