### PR TITLE
Fix infinite loop

### DIFF
--- a/lib/mavenlink/request.rb
+++ b/lib/mavenlink/request.rb
@@ -196,6 +196,7 @@ module Mavenlink
           response = request.page(i+=1).perform
           total_count = response.total_count
           result << page_records = response.results
+          break if response.results.empty?
         end
       end.each(&block)
     end

--- a/spec/lib/mavenlink/request_spec.rb
+++ b/spec/lib/mavenlink/request_spec.rb
@@ -377,5 +377,25 @@ describe Mavenlink::Request, stub_requests: true do
         expect(records[2]).to be_a Mavenlink::Model
       end
     end
+
+    # This would hang indefinitely
+    context "when the response says one result but none are returned", stub_requests: false do
+      let(:response) {
+        {
+          'count' => 1,
+          'results' => [],
+          'workspaces' => {}
+        }
+      }
+
+      before do
+        stubbed_requests.instance_variable_get(:@stack)[:get].clear
+        stub_request :get, /api\/v1\/workspaces(\?page=[0-9]+)?/, response
+      end
+
+      it "returns nothing" do
+        expect(subject.each_page.to_a.flatten).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a hotfix for a bug in Mavenlink where the api returns a payload
such as
```
{
  "count": 1,
  "results": [],
  "custom_field_values": {},
  "meta": {
    "count": 1,
    "page_count": 1,
    "page_number": 1,
    "page_size": 20
  }
}
```

Since we are looking for 1 but we continually get none in return, we
manually break the loop if the current page has nothing regardless of
what the count says.