### PR TITLE
Allow later active* gem versions

### DIFF
--- a/mavenlink.gemspec
+++ b/mavenlink.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.description = "Simple Ruby API for the Mavenlink API"
   s.summary = "Mavenlink API Ruby Wrapper"
 
-  s.add_runtime_dependency "activemodel", "~> 4.2"
-  s.add_runtime_dependency "activesupport", "~> 4.2"
+  s.add_runtime_dependency "activemodel", ">= 4.2"
+  s.add_runtime_dependency "activesupport", ">= 4.2"
   s.add_runtime_dependency "brainstem-adaptor", ">= 0.0.3"
   s.add_runtime_dependency "faraday", ">= 0.9.0"
   s.add_development_dependency "awesome_print", "~> 1.8"


### PR DESCRIPTION
This PR updates the gemspec to allow later `activesupport` and `activemodel` versions.