### PR TITLE
Update error handling for Rate Card Set Version publish method

### DIFF
--- a/lib/mavenlink/rate_card_set_version.rb
+++ b/lib/mavenlink/rate_card_set_version.rb
@@ -1,26 +1,23 @@
 module Mavenlink
   class RateCardSetVersion < Model
-    def publish
-      if persisted?
-        client.put("rate_card_set_versions/#{@id}/publish")
-        true
-      else
-        false
-      end
-    rescue Faraday::Error
-      false
+    def publish!
+      raise Mavenlink::Error, "Record not defined" unless persisted?
+
+      client.put("rate_card_set_versions/#{@id}/publish")
     end
 
     def clone_version(effective_date = nil)
       return false unless persisted?
 
       request.perform do
-        client.post(collection_name,
-                    clone_id: id,
-                    rate_card_set_version: {
-                      rate_card_set_id: rate_card_set_id,
-                      effective_date: effective_date
-                    })
+        client.post(
+          collection_name,
+          clone_id: id,
+          rate_card_set_version: {
+            rate_card_set_id: rate_card_set_id,
+            effective_date: effective_date
+          }
+        )
       end.results.first
     rescue Mavenlink::Error
       false

--- a/spec/lib/mavenlink/rate_card_set_version_spec.rb
+++ b/spec/lib/mavenlink/rate_card_set_version_spec.rb
@@ -2,31 +2,10 @@ require "spec_helper"
 
 describe Mavenlink::RateCardSetVersion, stub_requests: true, type: :model do
   subject { described_class.new(id: "7", rate_card_set_id: "1") }
-  let(:client) { double(Mavenlink::Client) }
 
-  describe "#publish" do
-    context "when the publish is successful" do
-      let(:publish_response) { { "activated" => true } }
-
-      before do
-        allow(subject).to receive(:persisted?) { true }
-        stub_request :put, "/api/v1/rate_card_set_versions/7/publish", publish_response
-      end
-
-      it "returns true" do
-        expect(subject.publish).to eq(true)
-      end
-    end
-
-    context "when the publish fails" do
-      before do
-        allow(subject).to receive(:client) { client }
-        allow(client).to receive(:put).and_raise(Faraday::Error, "Some message")
-      end
-
-      it "returns false" do
-        expect(subject.publish).to eq(false)
-      end
+  describe "#publish!" do
+    before do
+      allow(subject).to receive(:persisted?) { true }
     end
 
     context "when the record is not persisted" do
@@ -34,9 +13,14 @@ describe Mavenlink::RateCardSetVersion, stub_requests: true, type: :model do
         allow(subject).to receive(:persisted?) { false }
       end
 
-      it "returns false" do
-        expect(subject.publish).to eq(false)
+      it "raises an error" do
+        expect { subject.publish! }.to raise_error(Mavenlink::Error, "Record not defined")
       end
+    end
+
+    it "makes a put to the rate card set versions publish endpoint" do
+      expect_any_instance_of(Mavenlink::Client).to receive(:put).with("rate_card_set_versions/#{subject.id}/publish")
+      subject.publish!
     end
   end
 
@@ -66,23 +50,27 @@ describe Mavenlink::RateCardSetVersion, stub_requests: true, type: :model do
       end
 
       it "returns the new rate card set version" do
-        expect_any_instance_of(Mavenlink::Client).to receive(:post).with("rate_card_set_versions",
-                                                                         clone_id: subject.id,
-                                                                         rate_card_set_version: {
-                                                                           rate_card_set_id: subject.rate_card_set_id,
-                                                                           effective_date: nil
-                                                                         }).and_call_original
+        expect_any_instance_of(Mavenlink::Client).to receive(:post).with(
+          "rate_card_set_versions",
+          clone_id: subject.id,
+          rate_card_set_version: {
+            rate_card_set_id: subject.rate_card_set_id,
+            effective_date: nil
+          }
+        ).and_call_original
         expect(subject.clone_version).to eq(described_class.new(id: "8", effective_date: "2018-09-04", rate_card_set_id: "1"))
       end
 
       it "sends the effective_date parameter" do
         date = Date.new(2018, 9, 5)
-        expect_any_instance_of(Mavenlink::Client).to receive(:post).with("rate_card_set_versions",
-                                                                         clone_id: subject.id,
-                                                                         rate_card_set_version: {
-                                                                           rate_card_set_id: subject.rate_card_set_id,
-                                                                           effective_date: date
-                                                                         }).and_call_original
+        expect_any_instance_of(Mavenlink::Client).to receive(:post).with(
+          "rate_card_set_versions",
+          clone_id: subject.id,
+          rate_card_set_version: {
+            rate_card_set_id: subject.rate_card_set_id,
+            effective_date: date
+          }
+        ).and_call_original
         subject.clone_version(date)
       end
     end


### PR DESCRIPTION
Update the Rate Card Set Version publish method to always raise an error and rename it to `publish!`. 

Currently it will only return false for certain cases and raise an error for other unhandled exceptions. 

This change will always raise an error, which is the expected behavior for the method in Konekti. 

The PR to update this method name change in Konekti is https://github.com/mavenlink/konekti/pull/1799