### PR TITLE
Fix @associations_specification initialization

### DIFF
--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -130,6 +130,7 @@ module Mavenlink
     def initialize(attributes = {}, source_record = nil, client = Mavenlink.client)
       super(self.class.collection_name, (attributes[:id] || attributes["id"] || source_record.try(:id)), source_record.try(:response))
       @client = client
+      @associations_specification = self.class.specification["associations"]
       merge!(attributes)
     end
 

--- a/spec/lib/mavenlink/model_spec.rb
+++ b/spec/lib/mavenlink/model_spec.rb
@@ -195,6 +195,10 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
       expect(model.new).to respond_to :client
       expect(model.new.client).to be_a Mavenlink::Client
     end
+
+    it "sets the associations_specification" do
+      expect(model.new.instance_variable_get(:@associations_specification)).to be_present
+    end
   end
 
   describe "#client" do


### PR DESCRIPTION
When building a new record locally, the association specification is not
populated properly which prevents one from loading an association using
that same model. Ultimately this is something that should be fixed inside
of https://github.com/mavenlink/brainstem-adaptor