### PR TITLE
Update rate_card_set_version attributes and add `clone_version!`

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -988,7 +988,10 @@ rate_card_set_versions:
     - active
     - effective_date
     - used_currencies
+    - rate_card_set_id
+    - rate_card_version_ids
   create_attributes:
+    - clone_id
     - rate_card_set_id
     - effective_date
   update_attributes:

--- a/lib/mavenlink/rate_card_set_version.rb
+++ b/lib/mavenlink/rate_card_set_version.rb
@@ -8,7 +8,7 @@ module Mavenlink
 
     def clone_version(effective_date = nil)
       clone_version!(effective_date)
-    rescue Mavenlink::RecordInvalidError, Mavenlink::Error
+    rescue Mavenlink::Error
       false
     end
 

--- a/lib/mavenlink/rate_card_set_version.rb
+++ b/lib/mavenlink/rate_card_set_version.rb
@@ -7,7 +7,13 @@ module Mavenlink
     end
 
     def clone_version(effective_date = nil)
-      return false unless persisted?
+      clone_version!(effective_date)
+    rescue Mavenlink::RecordInvalidError, Mavenlink::Error
+      false
+    end
+
+    def clone_version!(effective_date = nil)
+      raise Mavenlink::RecordInvalidError, self unless persisted?
 
       request.perform do
         client.post(
@@ -19,8 +25,6 @@ module Mavenlink
           }
         )
       end.results.first
-    rescue Mavenlink::Error
-      false
     end
   end
 end


### PR DESCRIPTION
Co-authored-by: Kevin Cotugno <kcotugno@mavenlink.com>

This PR adds the missing `clone_id` create_attribute and the association foreign key attributes.

It also adds a `clone_version!` method to raise errors when cloning fails.