### PR TITLE
Update organization membership attributes

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -766,11 +766,18 @@ organization_memberships:
     - id
     - member_id
     - member_type
+    - primary
+    - geography_id
+    - department_id
   create_attributes:
     - geography_id
     - department_id
     - member_id
     - member_type
+  update_attributes:
+    - geography_id
+    - department_id
+    - primary
   associations:
     geography:
       foreign_key: geography_id

--- a/spec/lib/mavenlink/organization_membership_spec.rb
+++ b/spec/lib/mavenlink/organization_membership_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Mavenlink::OrganizationMembership, stub_requests: true, type: :model do
+  it_should_behave_like "model", "organization_memberships"
+
+  describe "associations" do
+    it { is_expected.to respond_to :geography }
+    it { is_expected.to respond_to :department }
+  end
+end


### PR DESCRIPTION
This PR adds organization membership `update_attributes`, including the new `primary` attribute.

It also backfills a missing spec for the organization membership model.