### PR TITLE
Fix model reloading and associations

### DIFF
--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -188,7 +188,7 @@ module Mavenlink
     # Reloads record from server
     # @return [self]
     def reload(response = nil)
-      (response ||= request.find(id).try(:response)) || raise(RecordNotFoundError, request)
+      (response ||= request.show(id).try(:response)) || raise(RecordNotFoundError, request)
       @id ||= response.results.first.try(:[], "id")
       load_fields_with(response)
       self
@@ -262,7 +262,7 @@ module Mavenlink
 
     # @param association [BrainstemAdaptor::Association]
     def reload_association(association)
-      (response = request.filter(association_load_filters).include(association.name).find(id).try(:response)) || raise(RecordNotFoundError, request)
+      (response = request.filter(association_load_filters).include(association.name).show(id).try(:response)) || raise(RecordNotFoundError, request)
       load_fields_with(response, [association.foreign_key])
     end
 

--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -120,13 +120,15 @@ module Mavenlink
 
     # @param source_record [Brainstem::Record, nil]
     # @param client [Mavenlink::Client]
+    # @param scope [Hash] filters used when requesting the model
     def self.wrap(source_record = nil, client = Mavenlink.client, scope = {})
       new({}, source_record, client, scope)
     end
 
     # @param attributes [Hash]
-    # @param source_record [BrainstemAdaptor::Record
+    # @param source_record [BrainstemAdaptor::Record]
     # @param client [Mavenlink::Client]
+    # @param scope [Hash] filters used when requesting the model
     def initialize(attributes = {}, source_record = nil, client = Mavenlink.client, scope = {})
       super(self.class.collection_name, (attributes[:id] || attributes["id"] || source_record.try(:id)), source_record.try(:response))
       @client = client

--- a/lib/mavenlink/request.rb
+++ b/lib/mavenlink/request.rb
@@ -17,6 +17,8 @@ module Mavenlink
     # @param new_scope [Hash]
     # @return [Mavenlink::Request]
     def chain(new_scope = {})
+      new_scope = {} if new_scope.nil?
+
       self.class.new(collection_name, client).tap do |new_request|
         new_request.scope.merge!(scope)
         new_request.scope.merge!(new_scope)
@@ -43,7 +45,7 @@ module Mavenlink
       raise ArgumentError if id.to_s.strip.empty?
 
       response = client.get("#{collection_name}/#{id}", stringify_include_value(scope))
-      Mavenlink::Response.new(response, client, scope).results.first
+      Mavenlink::Response.new(response, client, scope: scope).results.first
     end
 
     # @param text [String]
@@ -174,7 +176,7 @@ module Mavenlink
     # @return [Mavenlink::Response]
     def perform
       response = block_given? ? yield : client.get(collection_name, stringify_include_value(scope))
-      Mavenlink::Response.new(response, client)
+      Mavenlink::Response.new(response, client, scope: scope)
     end
 
     # Returns cached response

--- a/lib/mavenlink/request.rb
+++ b/lib/mavenlink/request.rb
@@ -39,6 +39,13 @@ module Mavenlink
       only(id).perform.results.first
     end
 
+    def show(id)
+      raise ArgumentError if id.to_s.strip.empty?
+
+      response = client.get("#{collection_name}/#{id}", stringify_include_value(scope))
+      Mavenlink::Response.new(response, client, scope).results.first
+    end
+
     # @param text [String]
     # @return [Mavenlink::Request]
     def search(text)

--- a/lib/mavenlink/response.rb
+++ b/lib/mavenlink/response.rb
@@ -1,12 +1,13 @@
 module Mavenlink
   class Response < BrainstemAdaptor::Response
-    attr_reader :client
+    attr_reader :client, :scope
 
     # @param response_data [String, Hash]
     # @param specification [BrainstemAdaptor::Specification]
     # @param client [Mavenlink::Client]
-    def initialize(response_data, client = Mavenlink.client, specification = Mavenlink.specification)
+    def initialize(response_data, client = Mavenlink.client, specification = Mavenlink.specification, scope: {})
       @client = client
+      @scope = scope
       super(response_data, specification)
     end
 
@@ -15,7 +16,7 @@ module Mavenlink
     # @override
     # @return [Array<MavenLink::Model>]
     def results
-      super.map { |record| Mavenlink::Model.models[record.collection_name].wrap(record, client) }
+      super.map { |record| Mavenlink::Model.models[record.collection_name].wrap(record, client, scope) }
     end
   end
 end

--- a/lib/mavenlink/story.rb
+++ b/lib/mavenlink/story.rb
@@ -5,7 +5,6 @@ module Mavenlink
 
     def association_load_filters
       {
-        all_on_account: true,
         show_archived: true,
         show_deleted: true,
         show_from_archived_workspaces: true

--- a/spec/lib/mavenlink/client_spec.rb
+++ b/spec/lib/mavenlink/client_spec.rb
@@ -47,6 +47,7 @@ describe Mavenlink::Client, stub_requests: true do
 
     before do
       stub_request :get, "/api/v1/workspaces?only=7", response
+      stub_request :get, "/api/v1/workspaces/7", response
     end
 
     specify do

--- a/spec/lib/mavenlink/model_spec.rb
+++ b/spec/lib/mavenlink/model_spec.rb
@@ -58,6 +58,7 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
 
   before do
     stub_request :get,    "/api/v1/monkeys?only=7", response
+    stub_request :get,    "/api/v1/monkeys?only=7", response
     stub_request :get,    "/api/v1/monkeys?only=8", "count" => 0, "results" => []
     stub_request :post,   "/api/v1/monkeys", response
     stub_request :put,    "/api/v1/monkeys/7", updated_response
@@ -463,7 +464,6 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
     subject { model.new(id: "7", name: "Maria") }
     let(:filters) do
       {
-        only: "7",
         include: "relatives",
         some: "filter"
       }.stringify_keys
@@ -484,7 +484,7 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
     end
 
     it "uses the specified filters" do
-      expect_any_instance_of(Faraday::Connection).to receive(:get).with("monkeys", hash_including(filters)) { faraday_response }
+      expect_any_instance_of(Faraday::Connection).to receive(:get).with("monkeys/#{subject.id}", hash_including(filters)) { faraday_response }
       expect(subject.relatives.count).to eq(1)
       expect(subject.relatives.first["id"]).to eq("10")
     end

--- a/spec/lib/mavenlink/request_spec.rb
+++ b/spec/lib/mavenlink/request_spec.rb
@@ -163,6 +163,31 @@ describe Mavenlink::Request, stub_requests: true do
     end
   end
 
+  describe "#show" do
+    before do
+      stub_request :get, "/api/v1/workspaces/7", one_record_response
+      stub_request :get, "/api/v1/workspaces/8", "errors" => [{ "type" => "system", "message" => "Not found" }]
+    end
+
+    context "when id is empty" do
+      it "raises an argument error" do
+        expect { subject.show(nil) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "existed record" do
+      it "returns record wrapped in a model" do
+        expect(subject.show(7)).to be_a Mavenlink::Workspace
+      end
+    end
+
+    context "record does not exist" do
+      it "raises an error" do
+        expect { subject.show(8) }.to raise_error(Mavenlink::InvalidRequestError)
+      end
+    end
+  end
+
   describe "#search" do
     specify do
       expect(subject.search("text").scope).to include(search: "text")

--- a/spec/lib/mavenlink/story_spec.rb
+++ b/spec/lib/mavenlink/story_spec.rb
@@ -84,7 +84,6 @@ describe Mavenlink::Story, stub_requests: true, type: :model do
   describe "#association_load_filters" do
     it "return filters to ensure we get hidden stories" do
       expect(subject.association_load_filters).to eq(
-        all_on_account: true,
         show_archived: true,
         show_deleted: true,
         show_from_archived_workspaces: true

--- a/spec/lib/mavenlink/workspace_spec.rb
+++ b/spec/lib/mavenlink/workspace_spec.rb
@@ -51,6 +51,7 @@ describe Mavenlink::Workspace, stub_requests: true, type: :model do
 
   before do
     stub_request :get,    "/api/v1/workspaces?only=7", response
+    stub_request :get,    "/api/v1/workspaces/7", response
     stub_request :get,    "/api/v1/workspaces?only=8", "count" => 0, "results" => []
     stub_request :post,   "/api/v1/workspaces", response
     stub_request :put,    "/api/v1/workspaces/7", updated_response


### PR DESCRIPTION
This PR adds support for `show` endpoints which allow us to fetch objects directly that may be typically hidden behind a specific filter needed when using `?only=` (for example, a story where `all_on_account: true` is required).

With `show` we can reliably reload models without having to worry about filters like `all_on_account`. There is still the need for some filters, though, so we will keep the previous `association_load_filters` (i.e. `show_deleted` is still required for `show`)

With this change also comes the addition of keeping the request scope on each model.