### PR TITLE
Call deep_dup on model scope

### DIFF
--- a/lib/mavenlink.rb
+++ b/lib/mavenlink.rb
@@ -1,5 +1,6 @@
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/core_ext/hash/slice"
+require "active_support/core_ext/object/deep_dup"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/string/inflections"
 require "active_model"

--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -133,7 +133,7 @@ module Mavenlink
       super(self.class.collection_name, (attributes[:id] || attributes["id"] || source_record.try(:id)), source_record.try(:response))
       @client = client
       @associations_specification = self.class.specification["associations"]
-      @scope = scope.except("page", "per_page", "only")
+      @scope = scope.deep_dup.except("page", "per_page", "only")
       merge!(attributes)
     end
 


### PR DESCRIPTION
We were seeing part of the scope shared across model instances. This PR solves this by `deep_dup`ing scope.