### PR TITLE
Revert "Add show method to use object/id on endpoints"

### DIFF
--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -191,7 +191,7 @@ module Mavenlink
     # Reloads record from server
     # @return [self]
     def reload(response = nil)
-      (response ||= request.show(id).try(:response)) || raise(RecordNotFoundError, request)
+      (response ||= request.find(id).try(:response)) || raise(RecordNotFoundError, request)
       @id ||= response.results.first.try(:[], "id")
       load_fields_with(response)
       self
@@ -265,7 +265,7 @@ module Mavenlink
 
     # @param association [BrainstemAdaptor::Association]
     def reload_association(association)
-      (response = request.filter(association_load_filters).include(association.name).show(id).try(:response)) || raise(RecordNotFoundError, request)
+      (response = request.filter(association_load_filters).include(association.name).find(id).try(:response)) || raise(RecordNotFoundError, request)
       load_fields_with(response, [association.foreign_key])
     end
 

--- a/lib/mavenlink/request.rb
+++ b/lib/mavenlink/request.rb
@@ -41,13 +41,6 @@ module Mavenlink
       only(id).perform.results.first
     end
 
-    def show(id)
-      raise ArgumentError if id.to_s.strip.empty?
-
-      response = client.get("#{collection_name}/#{id}", stringify_include_value(scope))
-      Mavenlink::Response.new(response, client, scope: scope).results.first
-    end
-
     # @param text [String]
     # @return [Mavenlink::Request]
     def search(text)

--- a/spec/lib/mavenlink/client_spec.rb
+++ b/spec/lib/mavenlink/client_spec.rb
@@ -47,7 +47,6 @@ describe Mavenlink::Client, stub_requests: true do
 
     before do
       stub_request :get, "/api/v1/workspaces?only=7", response
-      stub_request :get, "/api/v1/workspaces/7", response
     end
 
     specify do

--- a/spec/lib/mavenlink/model_spec.rb
+++ b/spec/lib/mavenlink/model_spec.rb
@@ -58,7 +58,6 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
 
   before do
     stub_request :get,    "/api/v1/monkeys?only=7", response
-    stub_request :get,    "/api/v1/monkeys?only=7", response
     stub_request :get,    "/api/v1/monkeys?only=8", "count" => 0, "results" => []
     stub_request :post,   "/api/v1/monkeys", response
     stub_request :put,    "/api/v1/monkeys/7", updated_response
@@ -464,6 +463,7 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
     subject { model.new(id: "7", name: "Maria") }
     let(:filters) do
       {
+        only: "7",
         include: "relatives",
         some: "filter"
       }.stringify_keys
@@ -484,7 +484,7 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
     end
 
     it "uses the specified filters" do
-      expect_any_instance_of(Faraday::Connection).to receive(:get).with("monkeys/#{subject.id}", hash_including(filters)) { faraday_response }
+      expect_any_instance_of(Faraday::Connection).to receive(:get).with("monkeys", hash_including(filters)) { faraday_response }
       expect(subject.relatives.count).to eq(1)
       expect(subject.relatives.first["id"]).to eq("10")
     end

--- a/spec/lib/mavenlink/request_spec.rb
+++ b/spec/lib/mavenlink/request_spec.rb
@@ -163,31 +163,6 @@ describe Mavenlink::Request, stub_requests: true do
     end
   end
 
-  describe "#show" do
-    before do
-      stub_request :get, "/api/v1/workspaces/7", one_record_response
-      stub_request :get, "/api/v1/workspaces/8", "errors" => [{ "type" => "system", "message" => "Not found" }]
-    end
-
-    context "when id is empty" do
-      it "raises an argument error" do
-        expect { subject.show(nil) }.to raise_error(ArgumentError)
-      end
-    end
-
-    context "existed record" do
-      it "returns record wrapped in a model" do
-        expect(subject.show(7)).to be_a Mavenlink::Workspace
-      end
-    end
-
-    context "record does not exist" do
-      it "raises an error" do
-        expect { subject.show(8) }.to raise_error(Mavenlink::InvalidRequestError)
-      end
-    end
-  end
-
   describe "#search" do
     specify do
       expect(subject.search("text").scope).to include(search: "text")

--- a/spec/lib/mavenlink/workspace_spec.rb
+++ b/spec/lib/mavenlink/workspace_spec.rb
@@ -51,7 +51,6 @@ describe Mavenlink::Workspace, stub_requests: true, type: :model do
 
   before do
     stub_request :get,    "/api/v1/workspaces?only=7", response
-    stub_request :get,    "/api/v1/workspaces/7", response
     stub_request :get,    "/api/v1/workspaces?only=8", "count" => 0, "results" => []
     stub_request :post,   "/api/v1/workspaces", response
     stub_request :put,    "/api/v1/workspaces/7", updated_response


### PR DESCRIPTION
This reverts commit 7292d9cb77edbd8c9391da856a06b23340331302.

Turns out not all endpoints have a show action. With the addition of the scope preserving functionality, we should not loose much by undoing this.