### PR TITLE
Update Mavenlink Gem to reflect new External Reference Support

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1749,12 +1749,17 @@ time_off_entries:
     - user_id
     - hours
     - requested_date
+    - external_reference
   update_attributes:
     - hours
+    - external_reference
   associations:
     user:
       foreign_key: user_id
       collection: users
+    external_references:
+      foreign_key: external_reference_ids
+      collection: external_references
 
 timesheet_submissions:
     attributes:

--- a/spec/lib/mavenlink/time_off_entry_spec.rb
+++ b/spec/lib/mavenlink/time_off_entry_spec.rb
@@ -5,5 +5,22 @@ describe Mavenlink::TimeOffEntry, stub_requests: true, type: :model do
 
   describe "association" do
     it { is_expected.to respond_to :user }
+    it { is_expected.to respond_to :external_references }
+  end
+
+  describe ".create_attributes" do
+    let(:subject) { described_class.create_attributes }
+
+    it "includes expected attributes" do
+      is_expected.to match_array(%w[user_id hours requested_date external_reference])
+    end
+  end
+
+  describe ".update_attributes" do
+    let(:subject) { described_class.update_attributes }
+
+    it "includes expected attributes" do
+      is_expected.to match_array(%w[hours external_reference])
+    end
   end
 end


### PR DESCRIPTION
#### Description
- [x] [Update Mavenlink Gem to reflect new External Reference Support](https://www.pivotaltracker.com/story/show/172744169)

#### Technical Changes
Add External Reference as a Create/Update attribute and an association for Time Off Entries in the Mavenlink Gem

#### Customer Commitment Deadline
ASAP