### PR TITLE
add recent_submission association to time_entries

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -379,6 +379,7 @@ expenses:
     - receipt_id # the id of an attached Receipt Attachment
     - expense_category_id # the id of its category
     - active_submission_id
+    - recent_submission_id
   create_attributes:
     - workspace_id # (required) the ID of the Workspace in which the expense will be created
     - date # (required) the date of the expense in ISO8601 format
@@ -426,6 +427,9 @@ expenses:
       collection: external_references
     active_submission:
       foreign_key: active_submission_id
+      collection: expense_report_submissions
+    recent_submission:
+      foreign_key: recent_submission_id
       collection: expense_report_submissions
     role:
       foreign_key: role_id

--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1678,6 +1678,9 @@ time_entries:
     active_submission:
       foreign_key: active_submission_id
       collection: timesheet_submissions
+    recent_submission:
+      foreign_key: recent_submission_id
+      collection: timesheet_submissions
     invoice:
       foreign_key: invoice_id
       collection: invoices
@@ -1710,6 +1713,7 @@ time_entries:
     - taxable
     - is_invoiced
     - active_submission_id
+    - recent_submission_id
     - invoice_id
   create_attributes:
     - workspace_id

--- a/spec/lib/mavenlink/expense_spec.rb
+++ b/spec/lib/mavenlink/expense_spec.rb
@@ -17,6 +17,7 @@ describe Mavenlink::Expense, stub_requests: true, type: :model do
     it { is_expected.to respond_to :receipt }
     it { is_expected.to respond_to :external_references }
     it { is_expected.to respond_to :active_submission }
+    it { is_expected.to respond_to :recent_submission }
     it { is_expected.to respond_to :role }
     it { is_expected.to respond_to :vendor }
   end

--- a/spec/lib/mavenlink/time_entry_spec.rb
+++ b/spec/lib/mavenlink/time_entry_spec.rb
@@ -15,6 +15,7 @@ describe Mavenlink::TimeEntry, stub_requests: true, type: :model do
     it { is_expected.to respond_to :story }
     it { is_expected.to respond_to :role }
     it { is_expected.to respond_to :active_submission }
+    it { is_expected.to respond_to :recent_submission }
     it { is_expected.to respond_to :invoice }
     it { is_expected.to respond_to :external_references }
   end


### PR DESCRIPTION
#### Overview
- [ ] User-facing
  - [ ] Productized Integration
  - [ ] Custom Integration
  - [ ] Affects multiple integrations
- [x] Not user-facing
- [ ] SDK

#### Description
- [x] [Add recent_submission to Time Entries](https://www.pivotaltracker.com/story/show/172968479)

#### Technical Changes
Add the recent_submission association to the Time Entries endpoint
Add recent_submission_id to the attributes
