### PR TITLE
Support bulk creation

### DIFF
--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -16,7 +16,7 @@ module Mavenlink
     # @param models [Array<Hash>]
     # @return [Array<Mavenlink::Model>]
     def self.bulk_create(models)
-      scoped.bulk_create(models)&.results
+      scoped.bulk_create(models).results
     end
 
     # @param attributes [Hash]

--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -13,6 +13,12 @@ module Mavenlink
       (name || "undefined").split(/\W+/).last.tableize.pluralize
     end
 
+    # @param models [Array<Hash>]
+    # @return [Array<Mavenlink::Model>]
+    def self.bulk_create(models)
+      scoped.bulk_create(models)&.results
+    end
+
     # @param attributes [Hash]
     # @return [Mavenlink::Model]
     def self.create(attributes = {})

--- a/lib/mavenlink/request.rb
+++ b/lib/mavenlink/request.rb
@@ -148,6 +148,12 @@ module Mavenlink
       "Mavenlink::#{collection_name.classify}".constantize.new(attributes, nil, client)
     end
 
+    # @param models [Array<Hash>]
+    # @return [Mavenlink::Response]
+    def bulk_create(models)
+      perform { client.post(collection_name, collection_name.pluralize => models) }
+    end
+
     # @param attributes [Hash]
     # @return [Mavenlink::Response]
     def create(attributes)

--- a/spec/lib/mavenlink/model_spec.rb
+++ b/spec/lib/mavenlink/model_spec.rb
@@ -78,6 +78,49 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
     end
   end
 
+  describe ".bulk_create" do
+    let(:models) do
+      [
+        {
+          name: "Masha"
+        },
+        {
+          name: "Masha 2"
+        }
+      ]
+    end
+
+    let(:response) do
+      {
+        "count" => 2,
+        "results" => [
+          {
+            "key" => "monkeys",
+            "id" => "8"
+          },
+          {
+            "key" => "monkeys",
+            "id" => "9"
+          }
+        ],
+        "monkeys" => {
+          "8" => {
+            "name" => "Masha",
+            "id" => "8"
+          },
+          "9" => {
+            "name" => "Masha 2",
+            "id" => "9"
+          }
+        }
+      }
+    end
+
+    it "sends a bulk_create request and returns the newly created mavenlink models" do
+      expect(model.bulk_create(models)).to match_array([Monkey, Monkey])
+    end
+  end
+
   describe ".create" do
     context "valid record" do
       specify do

--- a/spec/lib/mavenlink/request_spec.rb
+++ b/spec/lib/mavenlink/request_spec.rb
@@ -294,6 +294,53 @@ describe Mavenlink::Request, stub_requests: true do
     end
   end
 
+  describe "#bulk_create" do
+    let(:models) do
+      [
+        {
+          title: "Workspace One",
+          description: "Project uno"
+        },
+        {
+          title: "Another Workspace",
+          description: "Another project"
+        }
+      ]
+    end
+
+    let(:two_record_response) do
+      {
+        "count" => 2,
+        "results" => [
+          {
+            "key" => "workspaces",
+            "id" => "8"
+          },
+          {
+            "key" => "workspaces",
+            "id" => "9"
+          }
+        ],
+        "workspaces" => {
+          "8" => {
+            "title" => "Workspace One"
+          },
+          "9" => {
+            "title" => "Another Workspace"
+          }
+        }
+      }
+    end
+
+    it "posts to the collection with the given models" do
+      expect(client).to receive(:post).with(collection_name, collection_name.pluralize => models) { two_record_response }
+
+      response = subject.bulk_create(models)
+      expect(response).to be_a Mavenlink::Response
+      expect(response).to eq two_record_response
+    end
+  end
+
   describe "#create" do
     specify do
       expect(subject.create({})).to be_a Mavenlink::Response


### PR DESCRIPTION
This PR adds bulk creation support to the `Request` model and `Model` base class.

Bulk creations post a plural collection name key with the value being an array of hashes of attributes. Currently this is only supported by a very small number of endpoints but it is written to generically work as new objects start supporting bulk creation.