### PR TITLE
Add Request#show

### DIFF
--- a/lib/mavenlink/request.rb
+++ b/lib/mavenlink/request.rb
@@ -41,6 +41,15 @@ module Mavenlink
       only(id).perform.results.first
     end
 
+    # @param id [Integer, String]
+    # @return [BrainstemAdaptor::Record, nil]
+    def show(id)
+      raise ArgumentError if id.to_s.strip.empty?
+
+      response = client.get("#{collection_name}/#{id}", stringify_include_value(scope))
+      Mavenlink::Response.new(response, client, scope: scope, collection_name: collection_name).results.first
+    end
+
     # @param text [String]
     # @return [Mavenlink::Request]
     def search(text)

--- a/spec/lib/mavenlink/request_spec.rb
+++ b/spec/lib/mavenlink/request_spec.rb
@@ -163,6 +163,31 @@ describe Mavenlink::Request, stub_requests: true do
     end
   end
 
+  describe "#show" do
+    before do
+      stub_request :get, "/api/v1/workspaces/7", one_record_response
+      stub_request :get, "/api/v1/workspaces/8", "errors" => [{ "type" => "system", "message" => "Not found" }]
+    end
+
+    context "when id is empty" do
+      it "raises an argument error" do
+        expect { subject.show(nil) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "existed record" do
+      it "returns record wrapped in a model" do
+        expect(subject.show(7)).to be_a Mavenlink::Workspace
+      end
+    end
+
+    context "record does not exist" do
+      it "raises an error" do
+        expect { subject.show(8) }.to raise_error(Mavenlink::InvalidRequestError)
+      end
+    end
+  end
+
   describe "#search" do
     specify do
       expect(subject.search("text").scope).to include(search: "text")


### PR DESCRIPTION
This can be beneficial over a GET with only when an endpoint requires an additional argument (i.e. workspace_id). The show request should work without the additional argument.