### PR TITLE
Add Split Endpoint Call to Workspace Allocations

### DIFF
--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -1,7 +1,12 @@
 module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
-      client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
+      response = client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
+      ## update
+      # update_attributes(response.response_data["workspace_allocations"].values.first)
+
+      ## create
+      Mavenlink::WorkspaceAllocation.new(response["workspace_allocations"].values.last, nil, client)
     end
   end
 end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -1,8 +1,8 @@
 module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
-      client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
       client.put("#{collection_name}/#{id}", end_date: date.to_date.yesterday.to_s)
+      client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
     end
   end
 end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -1,7 +1,6 @@
 module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
-      client.put("#{collection_name}/#{id}", end_date: date.to_date.yesterday.to_s)
       client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
     end
   end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -2,7 +2,7 @@ module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
       client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
-      # client.put("#{collection_name}/#{id}", end_date: date.to_date.tomorrow.to_s)
+      client.put("#{collection_name}/#{id}", end_date: date.to_date.yesterday.to_s)
     end
   end
 end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -1,7 +1,8 @@
 module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
-      client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
+      client.put("#{collection_name}/split", split_date: date.to_date.tomorrow.to_s, workspace_allocation_id: id)
+      client.put("#{collection_name}/#{id}", end_date: date)
     end
   end
 end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -1,4 +1,7 @@
 module Mavenlink
   class WorkspaceAllocation < Model
+    def split_allocation(date)
+      client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
+    end
   end
 end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -1,8 +1,8 @@
 module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
-      client.put("#{collection_name}/split", split_date: date.to_date.tomorrow.to_s, workspace_allocation_id: id)
-      client.put("#{collection_name}/#{id}", end_date: date)
+      client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
+      # client.put("#{collection_name}/#{id}", end_date: date.to_date.tomorrow.to_s)
     end
   end
 end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -2,9 +2,7 @@ module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
       response = client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
-      ## update
       update_attributes(response["workspace_allocations"].values.first)
-      ## create
       Mavenlink::WorkspaceAllocation.new(response["workspace_allocations"].values.last, nil, client)
     end
   end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -3,8 +3,7 @@ module Mavenlink
     def split_allocation(date)
       response = client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
       ## update
-      # update_attributes(response.response_data["workspace_allocations"].values.first)
-
+      update_attributes(response.response_data["workspace_allocations"].values.first)
       ## create
       Mavenlink::WorkspaceAllocation.new(response["workspace_allocations"].values.last, nil, client)
     end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -3,7 +3,7 @@ module Mavenlink
     def split_allocation(date)
       response = client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
       ## update
-      update_attributes(response.response_data["workspace_allocations"].values.first)
+      update_attributes(response["workspace_allocations"].values.first)
       ## create
       Mavenlink::WorkspaceAllocation.new(response["workspace_allocations"].values.last, nil, client)
     end

--- a/lib/mavenlink/workspace_allocation.rb
+++ b/lib/mavenlink/workspace_allocation.rb
@@ -2,7 +2,7 @@ module Mavenlink
   class WorkspaceAllocation < Model
     def split_allocation(date)
       response = client.put("#{collection_name}/split", split_date: date, workspace_allocation_id: id)
-      update_attributes(response["workspace_allocations"].values.first)
+      self.attributes = response["workspace_allocations"].values.first
       Mavenlink::WorkspaceAllocation.new(response["workspace_allocations"].values.last, nil, client)
     end
   end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -19,7 +19,7 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
   end
 
   describe "#split_allocation" do
-    subject { described_class.new(id: "5555") }
+    subject { described_class.new(id: "5555", end_date: "2022-06-22") }
     let(:date) { Date.today.to_s }
     let(:response) do
       {
@@ -55,11 +55,14 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
       }.with_indifferent_access
     end
 
+    before do
+      allow(Mavenlink).to receive(:specification).and_return("monkeys" => { "attributes" => ["start_date", "end_date", "minutes", "created_at", "updated_at", "id"] })
+    end
+
     it "puts to the split route with the record id and date" do
       expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id) { response }
       expect(Mavenlink::WorkspaceAllocation).to receive(:new).with(response["workspace_allocations"].values.last, nil, subject.client)
-
-      subject.split_allocation(date)
+      expect { subject.split_allocation(date) }.to change { subject["end_date"] }.from("2022-06-22").to("2022-06-14")
     end
   end
 end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -23,7 +23,8 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
     let(:date) { Date.today.to_s }
 
     it "puts to the split route with the record id and date" do
-      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id)
+      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date.to_date.tomorrow.to_s, workspace_allocation_id: subject.id)
+      expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date)
       subject.split_allocation(date)
     end
   end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -24,7 +24,7 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
 
     it "puts to the split route with the record id and date" do
       expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date.to_date.tomorrow.to_s, workspace_allocation_id: subject.id)
-      expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date)
+      # expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date)
       subject.split_allocation(date)
     end
   end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -23,7 +23,7 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
     let(:date) { Date.today.to_s }
 
     it "puts to the split route with the record id and date" do
-      expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date.to_date.yesterday.to_s)
+      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id)
       subject.split_allocation(date)
     end
   end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -61,7 +61,7 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
 
     it "puts to the split route with the record id and date" do
       expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id) { response }
-      expect(subject).to receive(:update_attributes).with(response["workspace_allocations"].values.first)
+      # expect(Mavenlink::WorkspaceAllocation.attributes).to eq(response["workspace_allocations"].values.first)
       expect(Mavenlink::WorkspaceAllocation).to receive(:new).with(response["workspace_allocations"].values.last, nil, subject.client)
 
       subject.split_allocation(date)

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -17,4 +17,14 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
     it { is_expected.to respond_to "updater" }
     it { is_expected.to respond_to "external_references" }
   end
+
+  describe "#split_allocation" do
+    subject { described_class.new(id: "5555") }
+    let(:date) { Date.today.to_s }
+
+    it "puts to the split route with the record id and date" do
+      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id)
+      subject.split_allocation(date)
+    end
+  end
 end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -56,7 +56,7 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
     end
 
     before do
-      allow(Mavenlink).to receive(:specification).and_return("monkeys" => { "attributes" => ["start_date", "end_date", "minutes", "created_at", "updated_at", "id"] })
+      allow(Mavenlink).to receive(:specification).and_return("monkeys" => { "attributes" => %w[start_date end_date minutes created_at updated_at id] })
     end
 
     it "puts to the split route with the record id and date" do

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -24,7 +24,6 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
 
     it "puts to the split route with the record id and date" do
       expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date.to_date.yesterday.to_s)
-      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id)
       subject.split_allocation(date)
     end
   end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -55,13 +55,8 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
       }.with_indifferent_access
     end
 
-    before do
-      stub_request :put, "/api/v1/workspace_allocations/split?split_date=#{date},workspace_allocation_id=#{subject.id}", response
-    end
-
     it "puts to the split route with the record id and date" do
       expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id) { response }
-      # expect(Mavenlink::WorkspaceAllocation.attributes).to eq(response["workspace_allocations"].values.first)
       expect(Mavenlink::WorkspaceAllocation).to receive(:new).with(response["workspace_allocations"].values.last, nil, subject.client)
 
       subject.split_allocation(date)

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -23,7 +23,7 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
     let(:date) { Date.today.to_s }
 
     it "puts to the split route with the record id and date" do
-      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date.to_date.tomorrow.to_s, workspace_allocation_id: subject.id)
+      expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id)
       # expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date)
       subject.split_allocation(date)
     end

--- a/spec/lib/mavenlink/workspace_allocation_spec.rb
+++ b/spec/lib/mavenlink/workspace_allocation_spec.rb
@@ -23,8 +23,8 @@ describe Mavenlink::WorkspaceAllocation, stub_requests: true, type: :model do
     let(:date) { Date.today.to_s }
 
     it "puts to the split route with the record id and date" do
+      expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date.to_date.yesterday.to_s)
       expect(subject.client).to receive(:put).with("workspace_allocations/split", split_date: date, workspace_allocation_id: subject.id)
-      # expect(subject.client).to receive(:put).with("workspace_allocations/5555", end_date: date)
       subject.split_allocation(date)
     end
   end


### PR DESCRIPTION
Allow split endpoint to be called on workspace alllocations through a PUT call.