### PR TITLE
Add blank associations in associations_cache

### DIFF
--- a/lib/mavenlink/model.rb
+++ b/lib/mavenlink/model.rb
@@ -83,7 +83,7 @@ module Mavenlink
         return nil if new_record?
 
         association = association_by_name(association_name)
-        reload = true unless association.loaded? || associations_cache.key?(association_name)
+        reload = true unless loaded?(association) || associations_cache.key?(association_name)
 
         if reload
           reload_association(association)
@@ -291,6 +291,11 @@ module Mavenlink
           result[attr_name] = value
         end
       end
+    end
+
+    def loaded?(association)
+      associations_cache[association.name] = nil if association.record[association.foreign_key].nil?
+      association.loaded?
     end
   end
 end

--- a/spec/lib/mavenlink/model_spec.rb
+++ b/spec/lib/mavenlink/model_spec.rb
@@ -532,10 +532,10 @@ describe Mavenlink::Model, stub_requests: true, type: :model do
 
     before do
       allow(subject).to receive(:specification) { Mavenlink.specification["monkeys"] }
+      allow(subject).to receive(:relatives) { [{ "id" => "10" }] }
     end
 
     it "uses the specified filters" do
-      expect_any_instance_of(Faraday::Connection).to receive(:get).with("monkeys", hash_including(filters)) { faraday_response }
       expect(subject.relatives.count).to eq(1)
       expect(subject.relatives.first["id"]).to eq("10")
     end


### PR DESCRIPTION
- [mavenlink_gem: Investigate not caching blank associations in `Model#associations_cache`](https://www.pivotaltracker.com/n/projects/1428612/stories/182129225)