### PR TITLE
Support Primary Tag on Create Attributes for Organization Memberships

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1136,6 +1136,7 @@ organization_memberships:
     - department_id
     - member_id
     - member_type
+    - primary
   update_attributes:
     - geography_id
     - department_id


### PR DESCRIPTION
Adding primary tag to use in conjunction with Flatfile SOW change along with other projects that use organization memberships.