### PR TITLE
Cap Active Support version to 7.0.8

### DIFF
--- a/mavenlink.gemspec
+++ b/mavenlink.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
   s.add_runtime_dependency "activemodel", ">= 4.2"
-  s.add_runtime_dependency "activesupport", "<= 7.0.8"
+  s.add_runtime_dependency "activesupport", "<= 7.0.8", ">= 4.2"
   s.add_runtime_dependency "brainstem-adaptor", ">= 0.0.4"
   s.add_runtime_dependency "faraday", ">= 2.7.0"
   s.add_runtime_dependency "faraday-multipart", ">= 1.0.0"

--- a/mavenlink.gemspec
+++ b/mavenlink.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
   s.add_runtime_dependency "activemodel", ">= 4.2"
-  s.add_runtime_dependency "activesupport", "<= 7.0.8", ">= 4.2"
+  s.add_runtime_dependency "activesupport", ">= 4.2", "<= 7.0.8"
   s.add_runtime_dependency "brainstem-adaptor", ">= 0.0.4"
   s.add_runtime_dependency "faraday", ">= 2.7.0"
   s.add_runtime_dependency "faraday-multipart", ">= 1.0.0"

--- a/mavenlink.gemspec
+++ b/mavenlink.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
   s.add_runtime_dependency "activemodel", ">= 4.2"
-  s.add_runtime_dependency "activesupport", ">= 4.2"
+  s.add_runtime_dependency "activesupport", "<= 7.0.8"
   s.add_runtime_dependency "brainstem-adaptor", ">= 0.0.4"
   s.add_runtime_dependency "faraday", ">= 2.7.0"
   s.add_runtime_dependency "faraday-multipart", ">= 1.0.0"


### PR DESCRIPTION
Capping the version keeps us from running into the spec errors shown in this PR [#12080](https://github.com/CocoaPods/CocoaPods/issues/12080)