### PR TITLE
Lower time entry per_page to 5000

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -2347,7 +2347,7 @@ time_adjustments:
     - external_reference
 
 time_entries:
-  per_page: 10000
+  per_page: 5000
   associations:
     workspace:
       foreign_key: workspace_id


### PR DESCRIPTION
We are seeing some timeouts/500 error responses when fetching 10000 time entries per page. Fetching 5000 a page does not encounter the same issues.