### PR TITLE
Add expense `expense_budget_id`

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -817,6 +817,7 @@ expenses:
     - reimbursable
     - vendor_id
     - foreign_exchange_amount
+    - expense_budget_id
     - external_reference
   update_attributes:
     # NOTE(AC): check
@@ -830,6 +831,7 @@ expenses:
     - story_id
     - expense_category_id # the id of its category
     - foreign_exchange_amount
+    - expense_budget_id
     - external_reference
   associations:
     workspace:


### PR DESCRIPTION
Add support for assigning an expense budget to an expense on create and update.