### PR TITLE
IE - OX 7968- Expense Budget Attributes Update to include all publicly documented attributes

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -733,6 +733,10 @@ expense_budgets:
     - external_reference_ids
     - fixed_fee
     - fixed_fee_item_ids
+    - markup_per_unit_in_subunits
+    - markup_percentage
+    - markup_type
+    - quantity
     - story_id
     - title
     - workspace_id
@@ -744,6 +748,10 @@ expense_budgets:
     - expected_by
     - external_reference
     - fixed_fee
+    - markup_per_unit_in_subunits
+    - markup_percentage
+    - markup_type
+    - quantity
     - story_id
     - title
     - workspace_id
@@ -755,6 +763,10 @@ expense_budgets:
     - expected_by
     - external_reference
     - fixed_fee
+    - markup_per_unit_in_subunits
+    - markup_percentage
+    - markup_type
+    - quantity
     - story_id
     - title
   associations:

--- a/spec/lib/mavenlink/expense_budget_spec.rb
+++ b/spec/lib/mavenlink/expense_budget_spec.rb
@@ -13,6 +13,10 @@ describe Mavenlink::ExpenseBudget, stub_requests: true, type: :model do
     it { is_expected.to respond_to :expense_ids }
     it { is_expected.to respond_to :fixed_fee }
     it { is_expected.to respond_to :fixed_fee_item_ids }
+    it { is_expected.to respond_to :markup_per_unit_in_subunits }
+    it { is_expected.to respond_to :markup_percentage }
+    it { is_expected.to respond_to :markup_type }
+    it { is_expected.to respond_to :quantity }
     it { is_expected.to respond_to :story_id }
     it { is_expected.to respond_to :title }
     it { is_expected.to respond_to :workspace_id }
@@ -23,7 +27,7 @@ describe Mavenlink::ExpenseBudget, stub_requests: true, type: :model do
     let(:subject) { described_class.create_attributes }
 
     it "includes expected attributes" do
-      is_expected.to match_array(%w[billable burns_budget cost_per_unit_in_subunits description expected_by fixed_fee story_id title workspace_id external_reference])
+      is_expected.to match_array(%w[billable burns_budget cost_per_unit_in_subunits description expected_by fixed_fee markup_per_unit_in_subunits markup_percentage markup_type quantity story_id title workspace_id external_reference])
     end
   end
 
@@ -31,7 +35,7 @@ describe Mavenlink::ExpenseBudget, stub_requests: true, type: :model do
     let(:subject) { described_class.update_attributes }
 
     it "includes expected attributes" do
-      is_expected.to match_array(%w[billable burns_budget cost_per_unit_in_subunits description expected_by fixed_fee story_id title external_reference])
+      is_expected.to match_array(%w[billable burns_budget cost_per_unit_in_subunits description expected_by fixed_fee markup_per_unit_in_subunits markup_percentage markup_type quantity story_id title external_reference])
     end
   end
 end


### PR DESCRIPTION
Updated the expense_budgets specification to include all publicly documented attributes, create_attributes, and update_attributes.
