### PR TITLE
Update rate card model attributes and specs

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -1592,10 +1592,15 @@ rate_cards:
       foreign_key: external_reference_ids
       collection: external_references
   attributes:
-    - currency
-    - uses
     - id
+    - currency
+    - rate_card_set_title
+    - removable
+    - uses
+    - created_at
+    - updated_at
     - rate_card_set_id
+    - effective_rate_card_version_id
     - rate_card_version_ids
     - external_reference_ids
   create_attributes:
@@ -1613,6 +1618,9 @@ rate_card_sets:
     rate_card_set_versions:
       foreign_key: rate_card_set_version_ids
       collection: rate_card_set_versions
+    workspace_groups:
+      foreign_key: workspace_group_ids
+      collection: workspace_groups
   attributes:
     - id
     - title
@@ -1620,6 +1628,11 @@ rate_card_sets:
     - active_currencies
     - default_currencies
     - destroyable
+    - created_at
+    - updated_at
+    - rate_card_ids
+    - rate_card_set_version_ids
+    - workspace_group_ids
   create_attributes:
     - clone_version_id
     - title
@@ -1639,6 +1652,8 @@ rate_card_set_versions:
     - active
     - effective_date
     - used_currencies
+    - created_at
+    - updated_at
     - rate_card_set_id
     - rate_card_version_ids
   create_attributes:
@@ -1662,6 +1677,11 @@ rate_card_versions:
   attributes:
     - id
     - default_rate
+    - created_at
+    - updated_at
+    - rate_card_id
+    - rate_card_set_version_id
+    - rate_card_role_ids
   create_attributes:
     - default_rate
   update_attributes:
@@ -1678,6 +1698,10 @@ rate_card_roles:
   attributes:
     - id
     - rate
+    - created_at
+    - updated_at
+    - role_id
+    - rate_card_version_id
   create_attributes:
     - rate_card_version_id
     - role_id

--- a/spec/lib/mavenlink/rate_card_role_spec.rb
+++ b/spec/lib/mavenlink/rate_card_role_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Mavenlink::RateCardRole, stub_requests: true, type: :model do
+  it_should_behave_like "model", "rate_card_roles"
+
+  describe "associations" do
+    it { is_expected.to respond_to :role }
+    it { is_expected.to respond_to :rate_card_version }
+  end
+end

--- a/spec/lib/mavenlink/rate_card_set_spec.rb
+++ b/spec/lib/mavenlink/rate_card_set_spec.rb
@@ -1,6 +1,14 @@
 require "spec_helper"
 
 describe Mavenlink::RateCardSet, stub_requests: true, type: :model do
+  it_should_behave_like "model", "rate_card_sets"
+
+  describe "associations" do
+    it { is_expected.to respond_to :rate_cards }
+    it { is_expected.to respond_to :rate_card_set_versions }
+    it { is_expected.to respond_to :workspace_groups }
+  end
+
   subject { described_class.new(id: "7") }
   let(:client) { double(Mavenlink::Client) }
   let(:rate_card_set_id) { "9" }

--- a/spec/lib/mavenlink/rate_card_set_version_spec.rb
+++ b/spec/lib/mavenlink/rate_card_set_version_spec.rb
@@ -1,6 +1,13 @@
 require "spec_helper"
 
 describe Mavenlink::RateCardSetVersion, stub_requests: true, type: :model do
+  it_should_behave_like "model", "rate_card_set_versions"
+
+  describe "associations" do
+    it { is_expected.to respond_to :rate_card_set }
+    it { is_expected.to respond_to :rate_card_versions }
+  end
+
   subject { described_class.new(id: "7", rate_card_set_id: "1") }
 
   describe "#publish!" do

--- a/spec/lib/mavenlink/rate_card_spec.rb
+++ b/spec/lib/mavenlink/rate_card_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe Mavenlink::RateCard, stub_requests: true, type: :model do
+  it_should_behave_like "model", "rate_cards"
+
+  describe "associations" do
+    it { is_expected.to respond_to :rate_card_set }
+    it { is_expected.to respond_to :rate_card_versions }
+    it { is_expected.to respond_to :effective_rate_card_version }
+    it { is_expected.to respond_to :external_references }
+  end
+end

--- a/spec/lib/mavenlink/rate_card_version_spec.rb
+++ b/spec/lib/mavenlink/rate_card_version_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe Mavenlink::RateCardVersion, stub_requests: true, type: :model do
+  it_should_behave_like "model", "rate_card_versions"
+
+  describe "associations" do
+    it { is_expected.to respond_to :rate_card }
+    it { is_expected.to respond_to :rate_card_set_version }
+    it { is_expected.to respond_to :rate_card_roles }
+  end
+end


### PR DESCRIPTION
## Summary
- Add missing attributes to `rate_cards`, `rate_card_sets`, `rate_card_set_versions`, `rate_card_versions`, and `rate_card_roles` in `specification.yml`, aligned with the Kantata API documentation for rate card objects
- Add `workspace_groups` association to `rate_card_sets`
- Add new model specs for `RateCard`, `RateCardRole`, and `RateCardVersion`
- Update `RateCardSet` and `RateCardSetVersion` specs to include association tests and shared model behaviour