### PR TITLE
Add legacy revenue recognition method to workspace spec

### DIFF
--- a/lib/config/specification.yml
+++ b/lib/config/specification.yml
@@ -2937,6 +2937,7 @@ workspaces:
     - account_color_id
     - external_link
     - revenue_recognition_method
+    - legacy_revenue_recognition_method
     - primary_maven_id
     - participations
     - exclude_archived_stories_percent_complete
@@ -2979,6 +2980,7 @@ workspaces:
     - account_color_id
     - external_link
     - revenue_recognition_method
+    - legacy_revenue_recognition_method
     - exclude_archived_stories_percent_complete
     - stage
     - require_notes_on_time_entries

--- a/mavenlink.gemspec
+++ b/mavenlink.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
   s.add_runtime_dependency "activemodel", ">= 4.2"
-  s.add_runtime_dependency "activesupport", ">= 4.2", "< 8"
+  s.add_runtime_dependency "activesupport", ">= 4.2", "< 7.1"
   s.add_runtime_dependency "brainstem-adaptor", ">= 0.0.4"
   s.add_runtime_dependency "faraday", ">= 1.0"
   s.add_runtime_dependency "faraday-multipart", ">= 1.0.0"

--- a/mavenlink.gemspec
+++ b/mavenlink.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
   s.add_runtime_dependency "activemodel", ">= 4.2"
-  s.add_runtime_dependency "activesupport", ">= 4.2", "< 7.1"
+  s.add_runtime_dependency "activesupport", ">= 4.2", "< 8"
   s.add_runtime_dependency "brainstem-adaptor", ">= 0.0.4"
   s.add_runtime_dependency "faraday", ">= 1.0"
   s.add_runtime_dependency "faraday-multipart", ">= 1.0.0"

--- a/spec/lib/mavenlink/workspace_spec.rb
+++ b/spec/lib/mavenlink/workspace_spec.rb
@@ -229,6 +229,10 @@ describe Mavenlink::Workspace, stub_requests: true, type: :model do
       specify do
         expect(model.create_attributes).not_to be_empty
       end
+
+      it "includes legacy_revenue_recognition_method" do
+        expect(model.create_attributes).to include("legacy_revenue_recognition_method")
+      end
     end
 
     describe ".update_attributes" do
@@ -238,6 +242,10 @@ describe Mavenlink::Workspace, stub_requests: true, type: :model do
 
       specify do
         expect(model.update_attributes).not_to be_empty
+      end
+
+      it "includes legacy_revenue_recognition_method" do
+        expect(model.update_attributes).to include("legacy_revenue_recognition_method")
       end
     end
 


### PR DESCRIPTION
##### What

Add legacy_revenue_recognition_method to create_attributes and update_attributes in specification.yml, and update the activesupport constraint to support Rails 7.1+.

##### Why

Adds support for a new workspace API param that allows setting the legacy Insights-only revenue recognition method separately from the newer composite-ID-based revenue method field. Updating the schema ensures downstream apps can send the new attribute without validation errors.
